### PR TITLE
Add web.listen-address configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ To start collecting metrics, you simply need to:
 swift-health-exporter
 ```
 
-Metric are exposed at port `9520`. This port has been
+Metrics are exposed at port `9520` by default. This port has been
 [allocated](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)
 for `swift-health-exporter`.
+
+You can change the listening address and the port using the `--web.listen-address` flag.
+
+```sh
+swift-health-exporter --web.listen-address 127.0.0.1:9520
+```
 
 If the `swift-recon` and `swift-dispersion-report` are not in the directories
 named by the `$PATH` then you **must** provide the respective paths to
@@ -51,12 +57,12 @@ You can change the value for the max failures using the `--collector.max-failure
 
 Additionally, the following environment variables are recognized:
 
-| Variable                       | Required                                                                      | Description                                                                               |
-| ----------------               | ----------------                                                              | ----------------                                                                          |
-| `SWIFT_DISPERSION_REPORT_PATH` | yes, if executable not in `$PATH` and `dispersion` collector is enabled       | Path to the `swift-dispersion-report` executable.                                         |
-| `SWIFT_RECON_PATH`             | yes, if executable not in `$PATH` and any `recon.<name>` collector is enabled | Path to the `swift-recon` executable.                                                     |
-| `SWIFT_CLUSTER_RAW_CAPACITY_BYTES` | no | This cluster capacity value (in bytes) will be used for `swift_cluster_storage_capacity_bytes` metric instead of calculating total capacity using `swift-recon` tool. |
-| `DEBUG`                        | no                                                                            | If this option is set to `true` then `swift-health-exporter` will also output debug logs. |
+| Variable                           | Required                                                                      | Description                                                                                                                                                           |
+| ---------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SWIFT_DISPERSION_REPORT_PATH`     | yes, if executable not in `$PATH` and `dispersion` collector is enabled       | Path to the `swift-dispersion-report` executable.                                                                                                                     |
+| `SWIFT_RECON_PATH`                 | yes, if executable not in `$PATH` and any `recon.<name>` collector is enabled | Path to the `swift-recon` executable.                                                                                                                                 |
+| `SWIFT_CLUSTER_RAW_CAPACITY_BYTES` | no                                                                            | This cluster capacity value (in bytes) will be used for `swift_cluster_storage_capacity_bytes` metric instead of calculating total capacity using `swift-recon` tool. |
+| `DEBUG`                            | no                                                                            | If this option is set to `true` then `swift-health-exporter` will also output debug logs.                                                                             |
 
 ## Collectors
 
@@ -65,7 +71,7 @@ that are enabled by default can be disabled by providing a
 `--no-collector.<name>` flag.
 
 | Name                       | Enabled by default |
-| -------                    | -------            |
+| -------------------------- | ------------------ |
 | `dispersion`               | no                 |
 | `recon.diskusage`          | no                 |
 | `recon.driveaudit`         | no                 |
@@ -84,7 +90,7 @@ info and default timeout values.
 ### dispersion
 
 | Metric                                       | Labels  |
-| -------                                      | ------- |
+| -------------------------------------------- | ------- |
 | `swift_dispersion_container_copies_expected` |         |
 | `swift_dispersion_container_copies_found`    |         |
 | `swift_dispersion_container_copies_missing`  |         |
@@ -99,14 +105,13 @@ info and default timeout values.
 ### recon
 
 | Metric                       | Labels  |
-| -------                      | ------- |
+| ---------------------------- | ------- |
 | `swift_recon_task_exit_code` | `query` |
-
 
 #### recon.diskusage
 
 | Metric                                       | Labels               |
-| ----------------                             | -----------          |
+| -------------------------------------------- | -------------------- |
 | `swift_cluster_storage_capacity_bytes`       |                      |
 | `swift_cluster_storage_free_bytes`           |                      |
 | `swift_cluster_storage_used_bytes`           |                      |
@@ -116,13 +121,13 @@ info and default timeout values.
 #### recon.driveaudit
 
 | Metric                              | Labels       |
-| -------                             | -------      |
+| ----------------------------------- | ------------ |
 | `swift_cluster_drives_audit_errors` | `storage_ip` |
 
 #### recon.md5
 
 | Metric                          | Labels               |
-| -------                         | -------              |
+| ------------------------------- | -------------------- |
 | `swift_cluster_md5_all`         | `kind`               |
 | `swift_cluster_md5_errors`      | `storage_ip`, `kind` |
 | `swift_cluster_md5_matched`     | `storage_ip`, `kind` |
@@ -131,7 +136,7 @@ info and default timeout values.
 #### recon.quarantined
 
 | Metric                                 | Labels       |
-| -------                                | -------      |
+| -------------------------------------- | ------------ |
 | `swift_cluster_accounts_quarantined`   | `storage_ip` |
 | `swift_cluster_containers_quarantined` | `storage_ip` |
 | `swift_cluster_objects_quarantined`    | `storage_ip` |
@@ -139,7 +144,7 @@ info and default timeout values.
 #### recon.replication
 
 | Metric                                          | Labels       |
-| -------                                         | -------      |
+| ----------------------------------------------- | ------------ |
 | `swift_cluster_accounts_replication_age`        | `storage_ip` |
 | `swift_cluster_accounts_replication_duration`   | `storage_ip` |
 | `swift_cluster_containers_replication_age`      | `storage_ip` |
@@ -150,12 +155,12 @@ info and default timeout values.
 #### recon.unmounted
 
 | Metric                           | Labels       |
-| -------                          | -------      |
+| -------------------------------- | ------------ |
 | `swift_cluster_drives_unmounted` | `storage_ip` |
 
 #### recon.updater_sweep_time
 
 | Metric                                        | Labels       |
-| -------                                       | -------      |
+| --------------------------------------------- | ------------ |
 | `swift_cluster_containers_updater_sweep_time` | `storage_ip` |
 | `swift_cluster_objects_updater_sweep_time`    | `storage_ip` |

--- a/main.go
+++ b/main.go
@@ -35,7 +35,8 @@ import (
 )
 
 var cli struct {
-	Debug bool `env:"DEBUG" help:"Enable debug mode."`
+	Debug            bool   `env:"DEBUG" help:"Enable debug mode."`
+	WebListenAddress string `name:"web.listen-address" default:"0.0.0.0:9520" help:"Exporter listening address."`
 
 	MaxFailures int `name:"collector.max-failures" default:"4" help:"Max allowed failures for a specific collector."`
 
@@ -112,10 +113,7 @@ func main() {
 	http.Handle("/", handler)
 	http.Handle("/metrics", promhttp.Handler())
 
-	// this port has been allocated for Swift health exporter
-	// See: https://github.com/prometheus/prometheus/wiki/Default-port-allocations
-	listenAddr := ":9520"
-	err := httpext.ListenAndServeContext(httpext.ContextWithSIGINT(context.Background(), 1*time.Second), listenAddr, nil)
+	err := httpext.ListenAndServeContext(httpext.ContextWithSIGINT(context.Background(), 1*time.Second), cli.WebListenAddress, nil)
 	if err != nil {
 		logg.Fatal(err.Error())
 	}


### PR DESCRIPTION
Hi,

thanks for creating the exporter.
I made a small change which allows the user to define a listening address by providing the following configuration parameter. 

```bash
./swift-health-exporter --web.listen-address 127.0.0.1:9520
```

If no value is given it defaults to 0.0.0.0 which should match the current behavior.