### PR TITLE
Goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build artifacts
 build/
+dist/
 
 # test artifacts
 *.actual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## v1.0.0 (2023-06-14)
+## v1.0.1 - 2023-06-14
 
 Changes:
 
 * add automaxprocs
 * update dependencies including golang
 
-## v1.0.0 (2023-01-04)
+## v1.0.0 - 2023-01-04
 
 Initial release. We only used a rolling release up until this point.

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -27,12 +27,17 @@ golang:
 golangciLint:
   createConfig: true
 
+goReleaser:
+  createConfig: true
+
 githubWorkflow:
   ci:
     enabled: true
     coveralls: true
     ignorePaths: ["**.md"] # all Markdown files
   license:
+    enabled: true
+  release:
     enabled: true
   securityChecks:
     enabled: true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,45 @@
+# Release Guide
+
+We use [GoReleaser][goreleaser] and GitHub workflows for automating the release
+process. Follow the instructions below for creating a new release.
+
+1. Ensure local `master` branch is up to date with `origin/master`:
+
+   ```sh
+   git fetch --tags && git pull --tags
+   ```
+
+2. Ensure all checks are passing:
+
+   ```sh
+   make check
+   ```
+
+3. Update the [`CHANGELOG`](./CHANGELOG.md).
+   Make sure that the format is consistent especially the version heading.
+   We follow [semantic versioning][semver] for our releases.
+
+   You can check if the file format is correct by running [`release-info`][release-info] for the new version:
+
+   ```sh
+   go install github.com/sapcc/go-bits/tools/release-info@latest
+   release-info CHANGELOG.md X.Y.Z
+   ```
+
+   where `X.Y.Z` is the version that you are planning to release.
+
+4. Commit the updated changelog with message: `Release <version>`
+5. Create and push a new Git tag:
+
+   ```sh
+   git tag vX.Y.Z
+   git push --tags
+   ```
+
+   > [!IMPORTANT]
+   > Tags are prefixed with `v` and the GitHub release workflow is triggered for tags that match the `v[0-9]+.[0-9]+.[0-9]+` [gh-pattern].
+
+[release-info]: https://github.com/sapcc/go-bits/tree/master/tools/release-info
+[semver]: https://semver.org/spec/v2.0.0.html
+[gh-pattern]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags
+[goreleaser]: https://github.com/goreleaser/goreleaser


### PR DESCRIPTION
Do not merge before https://github.com/sapcc/go-makefile-maker/pull/122

I have updated the [`release-info`](https://github.com/sapcc/go-bits/tree/master/tools/release-info) tool so that we only need to conform to a specific version heading format. The format for the actual release notes between these headings can be arbitrary.

This will allow us to use `release-info` for all of our tools where we leverage GoReleaser GitHub workflow without having to refactor the entire changelog.